### PR TITLE
feat(setup): add ManagedSeed, shoot-seed provisioning and garden project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The environment supports two modes:
    ```bash
    ./gardenerless-setup.sh get-token
    ```
+
+   To get a read-only token for the `landscape-viewer` service account (see `resources/system-viewer-rbac.yaml`):
+
+   ```bash
+   ./gardenerless-setup.sh get-token --service-account landscape-viewer
+   ```
    
 ---
 
@@ -139,7 +145,7 @@ The environment supports two modes:
 | **reset-kcp-certs**              | —                                                                            | Remove certs/keys in `kcp/.kcp`                               |                                           |
 | **setup-gardener-crds**          | —                                                                            | Apply CRDs from `resources/crds/`                             |                                           |
 | **cluster-resources**            | —                                                                            | Apply `cloudprofile-*.yaml` & `seed-*.yaml` from `resources/` |                                           |
-| **get-token**                    | —                                                                            | Create/refresh 24h token for `dashboard-user` SA              |                                           |
+| **get-token**                    | `[--service-account <name>]`                                                 | Create/refresh 24h token for the given SA (default: `dashboard-user`)        |                                           |
 | **dashboard-kubeconfigs**        | —                                                                            | Print paths of generated dashboard kubeconfigs                |                                           |
 | **add-project**                  | `--name <name>`<br>`[--namespace <ns>]`                                      | Create one project (status=Ready)                             |                                           |
 | **add-projects**                 | `--count <n>`                                                                | Bulk-create *n* projects (random UIDs, status=Ready)          |                                           |

--- a/crds/shoots.core.gardener.cloud.yaml
+++ b/crds/shoots.core.gardener.cloud.yaml
@@ -2468,6 +2468,9 @@ spec:
                   description: ShootAdvertisedAddress contains information for the
                     shoot's Kube API server.
                   properties:
+                    application:
+                      description: Application is the name of the application that this address belongs to. e.g. prometheus--prometheus
+                      type: string
                     name:
                       description: Name of the advertised address. e.g. external
                       type: string

--- a/gardenerless-setup.sh
+++ b/gardenerless-setup.sh
@@ -122,7 +122,7 @@ patch_shoot_ready() {
   local project="${ns#garden-}"
   local now="$(now)"
   local patch_yaml
-  patch_yaml=$(apply_yaml_template "${RES_DIR}/status-shoot-ready.yaml" "$shoot" "$ns" | sed -E "s/DATEPLACEHOLDER/${now}/g")
+  patch_yaml=$(apply_yaml_template "${RES_DIR}/status-shoot-ready.yaml" "$shoot" "$ns" | sed -E "s/DATEPLACEHOLDER/${now}/g" | sed -e "s/PROJECTPLACEHOLDER/${project}/g")
   local json_patch
   json_patch=$(printf '%s' "$patch_yaml" | yq_to_json)
   run_quiet kubectl patch shoot "$shoot" -n "$ns" --type=merge --subresource=status -p "$json_patch"

--- a/gardenerless-setup.sh
+++ b/gardenerless-setup.sh
@@ -232,6 +232,7 @@ create_demo_ws() {
     run_quiet kubectl create sa dashboard-user -n garden
     run_quiet kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --serviceaccount=garden:dashboard-user
     run_quiet kubectl set subject clusterrolebinding cluster-admin --serviceaccount=garden:dashboard-user
+    run_quiet kubectl apply -f "$RES_DIR/system-viewer-rbac.yaml"
     setup_gardener_crds
     apply_cluster_resources
     case "$ws" in
@@ -283,7 +284,8 @@ Commands:
       Apply cloudprofile & seed YAMLs
 
   ${GREEN}get-token${NC}
-      Print dashboard-user service account token
+      ${YELLOW}[--service-account|-sa NAME]${NC}
+      Print service account token (default: dashboard-user)
 
   ${GREEN}dashboard-kubeconfigs${NC}
       Print paths of dashboard kubeconfigs
@@ -401,7 +403,15 @@ case "$COMMAND" in
     ;;
 
   get-token)
-    kubectl -n garden create token dashboard-user --duration 24h
+    SA_NAME="dashboard-user"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --service-account|-sa) SA_NAME="$2"; shift 2;;
+        -h|--help) show_help;;
+        *) log_error "Unknown option: $1"; exit 1;;
+      esac
+    done
+    kubectl -n garden create token "$SA_NAME" --duration 24h
     ;;
 
   dashboard-kubeconfigs)

--- a/gardenerless-setup.sh
+++ b/gardenerless-setup.sh
@@ -98,6 +98,10 @@ apply_cluster_resources() {
   for f in "$RES_DIR"/seed-*.yaml; do
     name=$(yq_read '.metadata.name' "$f")
     patch_seed_status "$name"
+    # Create managed seed for all seeds except soil
+    if [[ "$name" != "soil" ]]; then
+      create_managed_seed "$f"
+    fi
   done
 }
 
@@ -133,6 +137,48 @@ patch_seed_status() {
   local json_patch
   json_patch=$(printf '%s' "$patch_yaml" | yq_to_json)
   run_quiet kubectl patch seed "$seed" --type=merge --subresource=status -p "$json_patch"
+}
+
+patch_shoot_seed_status() {
+  local shoot="$1"
+  local now="$(now)"
+  local patch_yaml
+  patch_yaml=$(sed -e "s/NAMEPLACEHOLDER/${shoot}/g" -e "s/DATEPLACEHOLDER/${now}/g" "$RES_DIR/status-shoot-seed.yaml")
+  local json_patch
+  json_patch=$(printf '%s' "$patch_yaml" | yq_to_json)
+  run_quiet kubectl patch shoot "$shoot" -n garden --type=merge --subresource=status -p "$json_patch"
+  run_quiet kubectl label shoot "$shoot" -n garden shoot.gardener.cloud/status="healthy" --overwrite
+}
+
+create_managed_seed() {
+  local seed_file="$1"
+  local seed_name
+  seed_name=$(yq_read '.metadata.name' "$seed_file")
+  local provider
+  provider=$(yq_read '.spec.provider.type' "$seed_file")
+  local region
+  region=$(yq_read '.spec.provider.region' "$seed_file")
+  local zone
+  zone=$(yq_read '.spec.provider.zones[0]' "$seed_file")
+
+  log_info "${YELLOW}Creating managed seed shoot for '$seed_name'...${NC}"
+
+  # Create seed shoot
+  sed -e "s/NAMEPLACEHOLDER/${seed_name}/g" \
+      -e "s/CLOUDPROFILEPLACEHOLDER/${provider}/g" \
+      -e "s/PROVIDERPLACEHOLDER/${provider}/g" \
+      -e "s/REGIONPLACEHOLDER/${region}/g" \
+      -e "s/ZONEPLACEHOLDER/${zone}/g" \
+      -e "s/SEEDPLACEHOLDER/soil/g" \
+      "$RES_DIR/shoot-seed-template.yaml" | run_quiet kubectl apply -n garden -f -
+
+  # Patch seed shoot status
+  patch_shoot_seed_status "$seed_name"
+
+  # Create ManagedSeed resource
+  log_info "${YELLOW}Creating ManagedSeed resource for '$seed_name'...${NC}"
+  sed -e "s/NAMEPLACEHOLDER/${seed_name}/g" \
+      "$RES_DIR/managedseed-template.yaml" | run_quiet kubectl apply -n garden -f -
 }
 
 setup_kcp() {

--- a/gardenerless-setup.sh
+++ b/gardenerless-setup.sh
@@ -235,6 +235,8 @@ create_demo_ws() {
     run_quiet kubectl apply -f "$RES_DIR/system-viewer-rbac.yaml"
     setup_gardener_crds
     apply_cluster_resources
+    create_project_resource "garden" "garden"
+    patch_project_status "garden"
     case "$ws" in
         demo-animals) projects="cat dog" ;;
         demo-plants)  projects="pine rose sunflower" ;;

--- a/resources/managedseed-template.yaml
+++ b/resources/managedseed-template.yaml
@@ -1,0 +1,10 @@
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: NAMEPLACEHOLDER
+  namespace: garden
+spec:
+  shoot:
+    name: NAMEPLACEHOLDER
+  gardenlet:
+    bootstrap: BootstrapToken

--- a/resources/seed-alicloud.yaml
+++ b/resources/seed-alicloud.yaml
@@ -24,6 +24,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.alicloud.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-alicloud.yaml
+++ b/resources/seed-alicloud.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: alicloud-seed
+  name: alicloud
 spec:
   provider:
     type: alicloud
@@ -21,6 +21,9 @@ spec:
     nodes: 10.240.0.0/16
     pods: 10.241.128.0/17
     services: 10.241.0.0/17
+    shootDefaults:
+      pods: 100.64.0.0/12
+      services: 100.104.0.0/13
   settings:
     scheduling:
       visible: true

--- a/resources/seed-alicloud.yaml
+++ b/resources/seed-alicloud.yaml
@@ -27,8 +27,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.alicloud.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-aws.yaml
+++ b/resources/seed-aws.yaml
@@ -28,8 +28,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.aws.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-aws.yaml
+++ b/resources/seed-aws.yaml
@@ -25,6 +25,12 @@ spec:
       services: 100.104.0.0/13
   accessRestrictions:
     - name: eu-access-only
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.aws.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-aws.yaml
+++ b/resources/seed-aws.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: aws-seed
+  name: aws
 spec:
   provider:
     type: aws
@@ -20,6 +20,11 @@ spec:
     nodes: 10.240.0.0/16
     pods: 10.241.128.0/17
     services: 10.241.0.0/17
+    shootDefaults:
+      pods: 100.64.0.0/12
+      services: 100.104.0.0/13
+  accessRestrictions:
+    - name: eu-access-only
   settings:
     scheduling:
       visible: true

--- a/resources/seed-azure.yaml
+++ b/resources/seed-azure.yaml
@@ -25,6 +25,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.azure.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-azure.yaml
+++ b/resources/seed-azure.yaml
@@ -28,8 +28,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.azure.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-gcp-test.yaml
+++ b/resources/seed-gcp-test.yaml
@@ -24,6 +24,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.gcp-test.seed.fake.example.com
   settings:
     scheduling:
       visible: false

--- a/resources/seed-gcp-test.yaml
+++ b/resources/seed-gcp-test.yaml
@@ -27,8 +27,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.gcp-test.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-gcp-test.yaml
+++ b/resources/seed-gcp-test.yaml
@@ -1,18 +1,17 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: azure
+  name: gcp-test
 spec:
   provider:
-    type: azure
-    region: westeurope
+    type: gcp
+    region: us-central1
     zones:
-    - "1"
-    - "2"
-    - "3"
+    - us-central1-a
+    - us-central1-b
   dns:
     provider:
-      type: azure-dns
+      type: google-clouddns
       secretRef:
         name: ingress-secret
         namespace: garden
@@ -27,4 +26,4 @@ spec:
       services: 100.104.0.0/13
   settings:
     scheduling:
-      visible: true
+      visible: false

--- a/resources/seed-gcp.yaml
+++ b/resources/seed-gcp.yaml
@@ -25,6 +25,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.gcp.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-gcp.yaml
+++ b/resources/seed-gcp.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: gcp-seed
+  name: gcp
 spec:
   provider:
     type: gcp
@@ -22,6 +22,9 @@ spec:
     nodes: 10.240.0.0/16
     pods: 10.241.128.0/17
     services: 10.241.0.0/17
+    shootDefaults:
+      pods: 100.64.0.0/12
+      services: 100.104.0.0/13
   settings:
     scheduling:
       visible: true

--- a/resources/seed-gcp.yaml
+++ b/resources/seed-gcp.yaml
@@ -28,8 +28,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.gcp.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-openstack.yaml
+++ b/resources/seed-openstack.yaml
@@ -1,7 +1,7 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: openstack-seed
+  name: openstack
 spec:
   provider:
     type: openstack
@@ -22,6 +22,9 @@ spec:
     nodes: 10.240.0.0/16
     pods: 10.241.128.0/17
     services: 10.241.0.0/17
+    shootDefaults:
+      pods: 100.64.0.0/12
+      services: 100.104.0.0/13
   settings:
     scheduling:
       visible: true

--- a/resources/seed-openstack.yaml
+++ b/resources/seed-openstack.yaml
@@ -25,6 +25,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.openstack.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-openstack.yaml
+++ b/resources/seed-openstack.yaml
@@ -28,8 +28,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.openstack.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-soil.yaml
+++ b/resources/seed-soil.yaml
@@ -24,6 +24,12 @@ spec:
     shootDefaults:
       pods: 100.64.0.0/12
       services: 100.104.0.0/13
+  ingress:
+    controller:
+      kind: nginx
+      providerConfig:
+        use-proxy-protocol: true
+    domain: ingress.soil.seed.fake.example.com
   settings:
     scheduling:
       visible: true

--- a/resources/seed-soil.yaml
+++ b/resources/seed-soil.yaml
@@ -27,8 +27,6 @@ spec:
   ingress:
     controller:
       kind: nginx
-      providerConfig:
-        use-proxy-protocol: true
     domain: ingress.soil.seed.fake.example.com
   settings:
     scheduling:

--- a/resources/seed-soil.yaml
+++ b/resources/seed-soil.yaml
@@ -1,18 +1,17 @@
 apiVersion: core.gardener.cloud/v1beta1
 kind: Seed
 metadata:
-  name: azure
+  name: soil
 spec:
   provider:
-    type: azure
-    region: westeurope
+    type: aws
+    region: us-east-1
     zones:
-    - "1"
-    - "2"
-    - "3"
+    - us-east-1a
+    - us-east-1b
   dns:
     provider:
-      type: azure-dns
+      type: aws-route53
       secretRef:
         name: ingress-secret
         namespace: garden

--- a/resources/shoot-seed-template.yaml
+++ b/resources/shoot-seed-template.yaml
@@ -1,0 +1,43 @@
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: NAMEPLACEHOLDER
+  namespace: garden
+  annotations:
+    gardener.cloud/created-by: system:serviceaccount:garden:dashboard-user
+spec:
+  cloudProfileName: CLOUDPROFILEPLACEHOLDER
+  kubernetes:
+    version: 1.30.1
+  maintenance:
+    autoUpdate:
+      kubernetesVersion: true
+      machineImageVersion: true
+    timeWindow:
+      begin: 040000+0200
+      end: 050000+0200
+  networking:
+    nodes: 10.180.0.0/16
+  provider:
+    controlPlaneConfig: {}
+    infrastructureConfig: {}
+    type: PROVIDERPLACEHOLDER
+    workers:
+      - machine:
+          image:
+            name: gardenlinux
+            version: 15.4.20220818
+          type: m5.large
+        maxSurge: 1
+        maximum: 2
+        minimum: 1
+        name: worker-seed
+        volume:
+          size: 50Gi
+          type: gp3
+        zones:
+          - "ZONEPLACEHOLDER"
+  purpose: infrastructure
+  region: REGIONPLACEHOLDER
+  secretBindingName: PROVIDERPLACEHOLDER-secret
+  seedName: SEEDPLACEHOLDER

--- a/resources/status-seed.yaml
+++ b/resources/status-seed.yaml
@@ -1,4 +1,8 @@
 status:
+  allocatable:
+    shoots: "300"
+  capacity:
+    shoots: "300"
   conditions:
     - lastTransitionTime: DATEPLACEHOLDER
       lastUpdateTime: DATEPLACEHOLDER
@@ -24,6 +28,11 @@ status:
       reason: SystemComponentsRunning
       status: "True"
       type: SeedSystemComponentsHealthy
+  gardener:
+    id: x7kRmWpF2bNcYvH9LqJsTg4DnE6aUoXwZ1MfKj8QhVrA3CdBpY5iOlWuSeGtIb0m
+    name: gardenlet-856fbb875c-dfs7k
+    version: v1.141.0
+  kubernetesVersion: v1.34.3
   lastOperation:
     description: Error occurred during shoot reconciliation.
     lastUpdateTime: DATEPLACEHOLDER

--- a/resources/status-shoot-ready.yaml
+++ b/resources/status-shoot-ready.yaml
@@ -56,6 +56,19 @@ status:
   hibernated: false
   technicalID: shoot--NAMESPACEPLACEHOLDER--NAMEPLACEHOLDER
   uid: 123456781234-NAMESPACEPLACEHOLDER-NAMEPLACEHOLDER
+  advertisedAddresses:
+    - name: external
+      url: https://api.NAMEPLACEHOLDER.PROJECTPLACEHOLDER.shoot.fake.example.com
+    - name: internal
+      url: https://api.NAMEPLACEHOLDER.PROJECTPLACEHOLDER.internal.fake.example.com
+    - name: service-account-issuer
+      url: https://api.NAMEPLACEHOLDER.PROJECTPLACEHOLDER.internal.fake.example.com
+    - name: ingress/oauth2-ingress-0-1a27e0/0/0
+      url: https://prometheus-shoot-shoot--PROJECTPLACEHOLDER--NAMEPLACEHOLDER-0.ingress.fake.seed.example.com
+      application: prometheus--prometheus
+    - name: ingress/oauth2-ingress-a06281/0/0
+      url: https://plutono-shoot--PROJECTPLACEHOLDER--NAMEPLACEHOLDER.ingress.fake.seed.example.com
+      application: credativ--plutono
   lastOperation:
     description: Shoot cluster has been successfully reconciled.
     lastUpdateTime: 'DATEPLACEHOLDER'

--- a/resources/status-shoot-seed.yaml
+++ b/resources/status-shoot-seed.yaml
@@ -1,0 +1,82 @@
+status:
+  conditions:
+    - type: APIServerAvailable
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: HealthzRequestSucceeded
+      message: API server /healthz endpoint responded with success status code.
+    - type: ControlPlaneHealthy
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: ControlPlaneRunning
+      message: All control plane components are healthy.
+    - type: ObservabilityComponentsHealthy
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: ObservabilityComponentsRunning
+      message: All observability components are healthy.
+    - type: EveryNodeReady
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: EveryNodeReady
+      message: All nodes are ready.
+    - type: SystemComponentsHealthy
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: SystemComponentsRunning
+      message: All system components are healthy.
+    - type: ExtensionsReady
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: AllExtensionsReady
+      message: All extensions installed into the seed cluster are ready and healthy.
+    - type: GardenletReady
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: GardenletReady
+      message: Gardenlet is posting ready status.
+    - type: BackupBucketsReady
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: BackupBucketsAvailable
+      message: Backup Buckets are available.
+    - type: SeedSystemComponentsHealthy
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: SystemComponentsRunning
+      message: All system components are healthy.
+  constraints:
+    - type: HibernationPossible
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: NoProblematicWebhooks
+      message: All webhooks are properly configured.
+    - type: MaintenancePreconditionsSatisfied
+      status: 'True'
+      lastTransitionTime: 'DATEPLACEHOLDER'
+      lastUpdateTime: 'DATEPLACEHOLDER'
+      reason: NoProblematicWebhooks
+      message: All webhooks are properly configured.
+  gardener:
+    id: abcd1234-5678-90ab-cdef-1234567890ab
+    name: gardenlet-foo
+    version: v1
+  hibernated: false
+  technicalID: shoot--garden--NAMEPLACEHOLDER
+  uid: 123456781234-garden-NAMEPLACEHOLDER
+  lastOperation:
+    description: Shoot cluster has been successfully reconciled.
+    lastUpdateTime: 'DATEPLACEHOLDER'
+    progress: 100
+    state: Succeeded
+    type: Reconcile

--- a/resources/status-shoot-seed.yaml
+++ b/resources/status-shoot-seed.yaml
@@ -74,6 +74,19 @@ status:
   hibernated: false
   technicalID: shoot--garden--NAMEPLACEHOLDER
   uid: 123456781234-garden-NAMEPLACEHOLDER
+  advertisedAddresses:
+    - name: external
+      url: https://api.NAMEPLACEHOLDER.garden.shoot.fake.example.com
+    - name: internal
+      url: https://api.NAMEPLACEHOLDER.garden.internal.fake.example.com
+    - name: service-account-issuer
+      url: https://api.NAMEPLACEHOLDER.garden.internal.fake.example.com
+    - name: ingress/oauth2-ingress-0-1a27e0/0/0
+      url: https://prometheus-shoot-shoot--garden--NAMEPLACEHOLDER-0.ingress.fake.seed.example.com
+      application: prometheus--prometheus
+    - name: ingress/oauth2-ingress-a06281/0/0
+      url: https://plutono-shoot--garden--NAMEPLACEHOLDER.ingress.fake.seed.example.com
+      application: credativ--plutono
   lastOperation:
     description: Shoot cluster has been successfully reconciled.
     lastUpdateTime: 'DATEPLACEHOLDER'

--- a/resources/system-viewer-rbac.yaml
+++ b/resources/system-viewer-rbac.yaml
@@ -1,0 +1,205 @@
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      gardener.cloud/role: viewer
+  - matchLabels:
+      gardener.cloud/role: project-viewer
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    gardener.cloud/role: viewers
+    resources.gardener.cloud/managed-by: gardener
+    shoot.gardener.cloud/no-cleanup: "true"
+  name: gardener.cloud:system:viewers
+rules:
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - backupbuckets
+  - backupentries
+  - cloudprofiles
+  - namespacedcloudprofiles
+  - controllerinstallations
+  - quotas
+  - projects
+  - seeds
+  - shoots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.gardener.cloud
+  resources:
+  - credentialsbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - seedmanagement.gardener.cloud
+  - dashboard.gardener.cloud
+  - settings.gardener.cloud
+  - operations.gardener.cloud
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - resourcequotas
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.extensions.gardener.cloud
+  resources:
+  - observabilityapps/plutono
+  - observabilityapps/prometheus
+  - observabilityapps/prometheus-shoot
+  - observabilityapps/alertmanager-shoot
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  - resourcequotas
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - shoots
+  - secretbindings
+  - quotas
+  - namespacedcloudprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - settings.gardener.cloud
+  resources:
+  - openidconnectpresets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operations.gardener.cloud
+  resources:
+  - bastions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - shoots/viewerkubeconfig
+  verbs:
+  - create
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: landscape-viewer
+  namespace: garden
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:system:viewers:landscape-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:system:viewers
+subjects:
+- kind: ServiceAccount
+  name: landscape-viewer
+  namespace: garden


### PR DESCRIPTION
## Summary

- Add `--service-account` flag to `get-token` command
- Create garden project automatically during demo workspace setup
- Add ManagedSeed and shoot-seed provisioning support, including new
  resource templates and RBAC configuration
- Add nginx ingress controller config and advertised addresses to seed
  and shoot status resources